### PR TITLE
added switch case for Oculus_Link_Quest_2

### DIFF
--- a/Oculus Unity-Integration/Packages/com.oculus.unity-integration/Runtime/VR/Scripts/Util/OVRControllerHelper.cs
+++ b/Oculus Unity-Integration/Packages/com.oculus.unity-integration/Runtime/VR/Scripts/Util/OVRControllerHelper.cs
@@ -78,6 +78,7 @@ public class OVRControllerHelper : MonoBehaviour
 				activeControllerType = ControllerType.Rift;
 				break;
 			case OVRPlugin.SystemHeadset.Oculus_Quest_2:
+			case OVRPlugin.SystemHeadset.Oculus_Link_Quest_2:
 				activeControllerType = ControllerType.Quest2;
 				break;
 			default:


### PR DESCRIPTION
added switch case for Oculus_Link_Quest_2 so the correct controller is displayed when using link cable in the editor.